### PR TITLE
fix: use debian:12.4-slim for docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build go application
         working-directory: src
-        run: CGO_ENABLED=0 go build -a -installsuffix cgo -o assistant
+        run: go build -o assistant
 
       - name: upload-artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # 4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-alpine
+FROM debian:12.4-slim
 
 MAINTAINER Oliver Lippert <oliver@lipperts-web.de>
 


### PR DESCRIPTION
build locally it's roughly 120mb, so maybe even smaller then with go alpine

go isn't even needed since the binary is build already