### PR TITLE
ci: add workflow permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,8 @@
 name: Go test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lippoliv/billbee-house-number-assistant/security/code-scanning/2](https://github.com/lippoliv/billbee-house-number-assistant/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow only involves checking out the code and running tests, it likely only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` has restricted access, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
