### PR TITLE
ci: add workflow permissions to docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Build & Publish Docker image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lippoliv/billbee-house-number-assistant/security/code-scanning/1](https://github.com/lippoliv/billbee-house-number-assistant/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it likely requires `contents: read` to access the repository's contents and possibly no additional permissions for the `GITHUB_TOKEN`. If further permissions are needed, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
